### PR TITLE
fix(perl): Update players count on round start

### DIFF
--- a/scripts/HLstats_EventHandlers.plib
+++ b/scripts/HLstats_EventHandlers.plib
@@ -2007,6 +2007,12 @@ sub doEvent_WorldAction
 	my $rcmd = $g_servers{$s_addr}->{broadcasting_command};
 	my ($action) = @_;
 	my $desc;
+
+	# Always update player count on round start
+	if ($action eq "Round_Start") {
+		$g_servers{$s_addr}->updatePlayerCount();
+	}
+
 	my $act_players = $g_servers{$s_addr}->{num_trackable_players};
 	my $min_players = $g_servers{$s_addr}->{minplayers};
 	


### PR DESCRIPTION
It should prevent this kind of issue:
`HLstatsX:CE disabled! Need at least 25 active players (9/25)`
![image](https://github.com/user-attachments/assets/9463d80a-18d0-4fa8-8d4d-618b4d13d566)
